### PR TITLE
Signpost Private Variables in `test_cloud_mask.py`

### DIFF
--- a/cloud_mask/test_cloud_mask.py
+++ b/cloud_mask/test_cloud_mask.py
@@ -3,34 +3,34 @@ import numpy as np
 from cloud_mask import CloudMask
 
 
-IMAGE_SHAPE = (4, 512, 512)
-IMAGE_WITHOUT_CLOUDS = np.full(shape=IMAGE_SHAPE, fill_value=25, dtype=np.uint8)
-IMAGE_WITH_CLOUDS = np.array(
+_IMAGE_SHAPE = (4, 512, 512)
+_IMAGE_WITHOUT_CLOUDS = np.full(shape=_IMAGE_SHAPE, fill_value=25, dtype=np.uint8)
+_IMAGE_WITH_CLOUDS = np.array(
     [
-        np.full(shape=(IMAGE_SHAPE[1], IMAGE_SHAPE[2]), fill_value=250),
-        np.full(shape=(IMAGE_SHAPE[1], IMAGE_SHAPE[2]), fill_value=250),
-        np.full(shape=(IMAGE_SHAPE[1], IMAGE_SHAPE[2]), fill_value=250),
-        np.full(shape=(IMAGE_SHAPE[1], IMAGE_SHAPE[2]), fill_value=128),
+        np.full(shape=(_IMAGE_SHAPE[1], _IMAGE_SHAPE[2]), fill_value=250),
+        np.full(shape=(_IMAGE_SHAPE[1], _IMAGE_SHAPE[2]), fill_value=250),
+        np.full(shape=(_IMAGE_SHAPE[1], _IMAGE_SHAPE[2]), fill_value=250),
+        np.full(shape=(_IMAGE_SHAPE[1], _IMAGE_SHAPE[2]), fill_value=128),
     ],
     dtype=np.uint8,
 )
-RANDOM_IMAGE = np.random.uniform(low=25, high=250, size=IMAGE_SHAPE).astype(np.uint8)
-IMAGE_WITHOUT_CLOUDS_EXPECTED_OUTPUT = np.full(
-    shape=(IMAGE_SHAPE[1], IMAGE_SHAPE[2]), fill_value=False
+_RANDOM_IMAGE = np.random.uniform(low=25, high=250, size=_IMAGE_SHAPE).astype(np.uint8)
+_IMAGE_WITHOUT_CLOUDS_EXPECTED_OUTPUT = np.full(
+    shape=(_IMAGE_SHAPE[1], _IMAGE_SHAPE[2]), fill_value=False
 )
-IMAGE_WITH_CLOUDS_EXPECTED_OUTPUT = np.full(
-    shape=(IMAGE_SHAPE[1], IMAGE_SHAPE[2]), fill_value=True
+_IMAGE_WITH_CLOUDS_EXPECTED_OUTPUT = np.full(
+    shape=(_IMAGE_SHAPE[1], _IMAGE_SHAPE[2]), fill_value=True
 )
 
 
 class CloudMaskTests(unittest.TestCase):
     def test_image_without_clouds_produces_empty_mask(self) -> None:
-        cloud_mask = CloudMask(bands=IMAGE_WITHOUT_CLOUDS).create_cloud_mask()
-        np.testing.assert_array_equal(cloud_mask, IMAGE_WITHOUT_CLOUDS_EXPECTED_OUTPUT)
+        cloud_mask = CloudMask(bands=_IMAGE_WITHOUT_CLOUDS).create_cloud_mask()
+        np.testing.assert_array_equal(cloud_mask, _IMAGE_WITHOUT_CLOUDS_EXPECTED_OUTPUT)
 
     def test_image_entirely_clouds_produces_full_mask(self) -> None:
-        cloud_mask = CloudMask(bands=IMAGE_WITH_CLOUDS).create_cloud_mask()
-        np.testing.assert_array_equal(cloud_mask, IMAGE_WITH_CLOUDS_EXPECTED_OUTPUT)
+        cloud_mask = CloudMask(bands=_IMAGE_WITH_CLOUDS).create_cloud_mask()
+        np.testing.assert_array_equal(cloud_mask, _IMAGE_WITH_CLOUDS_EXPECTED_OUTPUT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Overview

Rename the constants (marked in ALL_CAPS) in `test_clour_mask.py` to have a leading underscore, indicating that they are not for use outside of the module.

## Changes

- Renamed the constants (marked in ALL_CAPS) in `test_clour_mask.py` to have a leading underscore.

## Testing

1. Run `test_cloud_mask.py`.

## Additional Information

https://peps.python.org/pep-0008/#descriptive-naming-styles

Closes #47 