### PR TITLE
Correctly set channel colour interpretation on clipping

### DIFF
--- a/training-data-download/clip_images.py
+++ b/training-data-download/clip_images.py
@@ -16,20 +16,24 @@ except FileExistsError:
 images_to_crop = os.listdir(SOURCE_FOLDER_PATH)
 
 for image in images_to_crop:
-    image_path = os.path.join(SOURCE_FOLDER_PATH, image)
+    raw_image_path = os.path.join(SOURCE_FOLDER_PATH, image)
+    processed_image_path = os.path.join(DESTINATION_FOLDER_PATH, image)
 
-    stats = gdal.Info(image_path, stats=True)
+    stats = gdal.Info(raw_image_path, stats=True)
     valid_percentage = float(re.search("STATISTICS_VALID_PERCENT=([\d.]*)", stats).group(1))
 
     if valid_percentage < 100:
-        print(f"Only {valid_percentage}% of '{image_path}' is valid. Skipping image.")
-        pass
+        print(f"Only {valid_percentage}% of '{raw_image_path}' is valid. Skipping image.")
+        continue
 
-    gdal.Translate(os.path.join(DESTINATION_FOLDER_PATH, image), os.path.join(SOURCE_FOLDER_PATH, image),
-                   srcWin=[0,0,TILE_WIDTH,TILE_WIDTH],
-                   format="GTiff",
-                   creationOptions=["COMPRESS=DEFLATE"],
-                   scaleParams=[[-1, 1,-2**(BIT_DEPTH-1),(2**BIT_DEPTH)-1]],
-                   outputType=gdal.GDT_Int16,
+    gdal.Translate(".tmp.tiff", raw_image_path,
+                   srcWin=[0,0,TILE_WIDTH,TILE_WIDTH], # Crop to tile size
+                   format="GTiff", # Leave format as GeoTiff
+                   creationOptions=["COMPRESS=DEFLATE"], # Compress image
+                   bandList=[2,3,4,1], # Reorder bands to R,G,B,NIR
+                   scaleParams=[[-1, 1,0,2**(BIT_DEPTH)]], # Scale input from -1 to 1 float to BIT_DEPTH unsigned integer
+                   outputType=gdal.GDT_UInt16,
                    noData=0,
                    )
+    gdal.Translate(processed_image_path, ".tmp.tiff", options=["-colorinterp","red,green,blue,alpha"]) # Add colour interpretation information to bands
+    os.remove(".tmp.tiff")


### PR DESCRIPTION
## Overview

This updates `clip_images.py` to both correctly set the colour channel interpretation information (allowing correct loading by OpenCV and other software). NIR is mapped to the Alpha channel.

`clip_images.py` will now also not clip partial images where data is missing, filtering these out of the dataset.

## Changes

Modifications to `clip_images.py` listed above, bug fix in bit depth scaling to use correct formula.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## MR Acceptance Checklist

<!-- To be filled out by the assignee before submitting for review. The purpose of this checklist is to let the reviewers know at a glane what the assignee believes is complete and what they believe still needs work or would like input on, and act as a guideline for review as well as initial development. -->

- [ ] This MR actually solves the problem it was meant to solve.
- [ ] It does so in the most appropriate way. 
- [ ] It satisfies all requirements. 
- [ ] There are no remaining bugs, logical problems, uncovered edge cases, or known vulnerabilities. 
- [ ] For the code that this change impacts, you believe that the automated tests validate functionality that is highly important to the user. If the existing automated tests do not cover the above functionality, you have added the necessary additional tests or added an issue to describe the automation testing gap and linked it to this MR. 
- [ ] This MR has been validated, and the method for validation and evidence are included in this MR.
- [ ] This MR does not harm performance, or you have asked a reviewer to help assess the performance impact.